### PR TITLE
Fix privilege level retrieval for Python 3

### DIFF
--- a/tacacs_plus/client.py
+++ b/tacacs_plus/client.py
@@ -256,7 +256,7 @@ class TACACSClient(object):
                 if arg.find(b'=') > -1]
             )
             user_priv_lvl = int(reply_arguments.get(
-                'priv-lvl', TAC_PLUS_PRIV_LVL_MAX))
+                six.b('priv-lvl'), TAC_PLUS_PRIV_LVL_MAX))
             if user_priv_lvl < priv_lvl:
                 reply.status = TAC_PLUS_AUTHOR_STATUS_FAIL
         return reply

--- a/tacacs_plus/client.py
+++ b/tacacs_plus/client.py
@@ -225,7 +225,6 @@ class TACACSClient(object):
         Authorize with a TACACS+ server.
 
         :param username:
-        :param password:
         :param arguments:      The authorization arguments
         :param authen_type:    TAC_PLUS_AUTHEN_TYPE_ASCII,
                                TAC_PLUS_AUTHEN_TYPE_PAP,

--- a/tacacs_plus/client.py
+++ b/tacacs_plus/client.py
@@ -251,9 +251,9 @@ class TACACSClient(object):
                 'recv body <%s>' % reply
             ]))
             reply_arguments = dict([
-                arg.split(b'=', 1)
+                arg.split(six.b('='), 1)
                 for arg in reply.arguments or []
-                if arg.find(b'=') > -1]
+                if arg.find(six.b('=')) > -1]
             )
             user_priv_lvl = int(reply_arguments.get(
                 six.b('priv-lvl'), TAC_PLUS_PRIV_LVL_MAX))


### PR DESCRIPTION
Hi there,

There is a Python 3 problem during the privilege level retrieval: the `reply_arguments` dict contains keys and values byte strings but the `priv-lvl` key used is a string, so actual retrieval will always fail.
The first commit fixes that.
I took the liberty to add two small tests to check the comparison but my TACACS knowledge is limited so feel free to tell me if something wrong.

I also did some minor style cleanup: it seems you try to use as much as possible `six.b` instead of the `b` string prefix for older Python compatibility so I modified the code in `TACACSClient.authorize` to reflect that, this is in the second commit (feel free to discard it if you don't like it).

The third commit fix a small issue in the method's docstring.

By the way, I commented in #4, could you take a look?
I am willing to create another pull request to fix the issue I raised (be it either to fail on missing `priv-lvl` attribute or add another kwarg or something else you may prefer) but I would prefer to know your position.

Regards.
