### PR TITLE
Fix #22: only compare major version

### DIFF
--- a/tacacs_plus/client.py
+++ b/tacacs_plus/client.py
@@ -128,7 +128,7 @@ class TACACSClient(object):
             # If the reply header doesn't match, it's likely a non-TACACS+ TCP
             # service answering with data we don't antipicate.  Bail out.
             if any([
-                resp_header.version != header.version,
+                resp_header.version_max != header.version_max,
                 resp_header.type != header.type,
                 resp_header.session_id != header.session_id
             ]):


### PR DESCRIPTION
According to section 4.4.1 of the RFC (https://tools.ietf.org/html/draft-ietf-opsawg-tacacs-10), the minor version doesnt effect authorization:

>The changes between minor_version 0 and 1 apply only to the authentication process 

>All authorisation and accounting and ASCII authentication use minor_version number of 0

I think the check on this line should only compare major versions.
Testing: 
```
client = TACACSClient('10.1.7.14', 49, 'testing123', timeout=4)
client.version_min`
0

client.authenticate('tadmin', 'chap', authen_type=TAC_PLUS_AUTHEN_TYPES['chap'], chap_ppp_id='a', chap_challenge='b')
<tacacs_plus.authentication.TACACSAuthenticationReply object at 0x7ffff5ae6a90>

client.version_min
1

client.authorize('tadmin', arguments=[], authen_type=TAC_PLUS_AUTHEN_TYPES['chap'])
<tacacs_plus.authorization.TACACSAuthorizationReply object at 0x7ffff5ae6d10>

client.version_min
1
```