### PR TITLE
Ensure key is None to support unencrypted packets

### DIFF
--- a/bin/tacacs_client
+++ b/bin/tacacs_client
@@ -149,6 +149,8 @@ def account(cli, args):
 def get_cli(args):
     if not args.key:
         args.key = getpass.getpass("tacacs+ shared key: ")
+    if not args.key:
+        args.key = None
     family = socket.AF_INET
     if args.v6:
         family = family = socket.AF_INET6


### PR DESCRIPTION
In order to support unencrypted packets, the secret has to be `None`:

https://github.com/ansible/tacacs_plus/blob/de0d01372169c8849fa284d75097e57367c8930f/tacacs_plus/packet.py#L86-L88

However, `getpass()` will return a empty string, which will not if you intent to generate encrypted packets.

https://github.com/ansible/tacacs_plus/blob/de0d01372169c8849fa284d75097e57367c8930f/bin/tacacs_client#L150-L151

This commit simple sets `args.key` to `None` in case no secret has been provided.