### PR TITLE
Set header flags correctly if body is not encrypted

### DIFF
--- a/tacacs_plus/client.py
+++ b/tacacs_plus/client.py
@@ -109,7 +109,8 @@ class TACACSClient(object):
             req_type,
             self.session_id,
             len(body.packed),
-            seq_no=seq_no
+            seq_no=seq_no,
+            flags=(0 if self.secret else 1)
         )
         packet = TACACSPacket(header, body.packed, self.secret)
 


### PR DESCRIPTION
Unencrypted packets need to have the header flags set to 0x01